### PR TITLE
wikiparser now formats turrets into tooltip templates

### DIFF
--- a/ketchupbot-framework/WikiParser.cs
+++ b/ketchupbot-framework/WikiParser.cs
@@ -256,6 +256,25 @@ public static partial class WikiParser
                     // Get rid of newlines in the description parameter
                     value = value.Replace("\n", " ");
                     break;
+                case "tiny_turrets":
+                case "small_turrets":
+                case "med_turrets":
+                case "large_turrets":
+                case "huge_turrets":
+                    // Convert turrets to tooltips
+                    var values = Regex.Split(value, @"\r?\n+");
+                    var formatted = values
+                        .Select(val => val.Trim())
+                        .Where(val => !string.IsNullOrEmpty(val))
+                        .Select(val =>
+                        {
+                            if (Regex.IsMatch(val, @"^\{\{Tooltip\|[^|]+\|\{\{TurretInfbox\|[^}]+\}\}\}\}$"))
+                                return val;
+                            else
+                            return $"{{{{Tooltip|{val}|{{{{TurretInfobox|{val}}}}}}}}}";
+                        });
+                    value = string.Join("\n\n", formatted);
+                    break;
             }
 
             sanitizedData[key] = value;


### PR DESCRIPTION
Plz message me on discord to discuss, this will reformat turrets so they are wrapped in the Tooltip template that allows you to see the turret info by hovering over the turret names in the infobox

Adding this immediately will have no visual change to the wiki, but in order for the tooltips to work the JS will have to be added sitewide

I don't know c# so hopefully this doesn't break stuff